### PR TITLE
Update GH actions to match OGD platform version 24.12

### DIFF
--- a/.github/actions/OGD_automation_dependencies/action.yml
+++ b/.github/actions/OGD_automation_dependencies/action.yml
@@ -25,7 +25,7 @@ runs:
     #     echo "::set-output name=dir::$(pip cache dir)"
     #   shell: bash
     # - name: Set up pip cache
-    #   uses: actions/cache@v2
+    #   uses: actions/cache@v4
     #   id: cache
     #   with:
     #     path: ${{ steps.pip-cache.outputs.dir }}

--- a/.github/workflows/aqualab.yml
+++ b/.github/workflows/aqualab.yml
@@ -28,7 +28,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/aqualab.yml
+++ b/.github/workflows/aqualab.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/bacteria.yml
+++ b/.github/workflows/bacteria.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/bacteria.yml
+++ b/.github/workflows/bacteria.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/balloon.yml
+++ b/.github/workflows/balloon.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/balloon.yml
+++ b/.github/workflows/balloon.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/bloom.yml
+++ b/.github/workflows/bloom.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/bloom.yml
+++ b/.github/workflows/bloom.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/cycle_carbon.yml
+++ b/.github/workflows/cycle_carbon.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/cycle_carbon.yml
+++ b/.github/workflows/cycle_carbon.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/cycle_nitrogen.yml
+++ b/.github/workflows/cycle_nitrogen.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/cycle_nitrogen.yml
+++ b/.github/workflows/cycle_nitrogen.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/cycle_water.yml
+++ b/.github/workflows/cycle_water.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/cycle_water.yml
+++ b/.github/workflows/cycle_water.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/earthquake.yml
+++ b/.github/workflows/earthquake.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/earthquake.yml
+++ b/.github/workflows/earthquake.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/icecube.yml
+++ b/.github/workflows/icecube.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/icecube.yml
+++ b/.github/workflows/icecube.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/journalism.yml
+++ b/.github/workflows/journalism.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/journalism.yml
+++ b/.github/workflows/journalism.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/jowilder.yml
+++ b/.github/workflows/jowilder.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/jowilder.yml
+++ b/.github/workflows/jowilder.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -42,6 +42,6 @@ jobs:
 
   # 4. Cleanup & complete
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -20,7 +20,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # 2. Remote config 
     - name: Configure Git User

--- a/.github/workflows/lakeland.yml
+++ b/.github/workflows/lakeland.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/lakeland.yml
+++ b/.github/workflows/lakeland.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/magnet.yml
+++ b/.github/workflows/magnet.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/magnet.yml
+++ b/.github/workflows/magnet.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/mashopolis.yml
+++ b/.github/workflows/mashopolis.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/mashopolis.yml
+++ b/.github/workflows/mashopolis.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/match.yml
+++ b/.github/workflows/match.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/match.yml
+++ b/.github/workflows/match.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/penguins.yml
+++ b/.github/workflows/penguins.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/penguins.yml
+++ b/.github/workflows/penguins.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/shadowspect.yml
+++ b/.github/workflows/shadowspect.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/shadowspect.yml
+++ b/.github/workflows/shadowspect.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/shipwrecks.yml
+++ b/.github/workflows/shipwrecks.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/shipwrecks.yml
+++ b/.github/workflows/shipwrecks.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/slide.yml
+++ b/.github/workflows/slide.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/slide.yml
+++ b/.github/workflows/slide.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/thermolab.yml
+++ b/.github/workflows/thermolab.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/thermolab.yml
+++ b/.github/workflows/thermolab.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/transformation_quest.yml
+++ b/.github/workflows/transformation_quest.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/transformation_quest.yml
+++ b/.github/workflows/transformation_quest.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/verify_VPN.yml
+++ b/.github/workflows/verify_VPN.yml
@@ -10,7 +10,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # 2. Remote config 
     - name: Set restart mode

--- a/.github/workflows/waves.yml
+++ b/.github/workflows/waves.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/waves.yml
+++ b/.github/workflows/waves.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/weather_station.yml
+++ b/.github/workflows/weather_station.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/weather_station.yml
+++ b/.github/workflows/weather_station.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 

--- a/.github/workflows/wind.yml
+++ b/.github/workflows/wind.yml
@@ -27,7 +27,7 @@ jobs:
 
     # 1. Local checkout & config
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up config.py file from config.py.template
       uses: ./.github/actions/OGD_automation_config
       with:

--- a/.github/workflows/wind.yml
+++ b/.github/workflows/wind.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./*.log
 


### PR DESCRIPTION
Update the checkout and upload-artifact action versions in use by the scripts.

Resolves #2.