### PR TITLE
Only upload automation logs if an error occurred.

### DIFF
--- a/.github/workflows/aqualab.yml
+++ b/.github/workflows/aqualab.yml
@@ -65,6 +65,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/aqualab.yml
+++ b/.github/workflows/aqualab.yml
@@ -62,6 +62,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/bacteria.yml
+++ b/.github/workflows/bacteria.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/bacteria.yml
+++ b/.github/workflows/bacteria.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/balloon.yml
+++ b/.github/workflows/balloon.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/balloon.yml
+++ b/.github/workflows/balloon.yml
@@ -64,6 +64,8 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
+        path: ./*.log.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/balloon.yml
+++ b/.github/workflows/balloon.yml
@@ -65,7 +65,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.TABLE_NAME }}-automation-logs
-        path: ./*.log.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/bloom.yml
+++ b/.github/workflows/bloom.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/bloom.yml
+++ b/.github/workflows/bloom.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/cycle_carbon.yml
+++ b/.github/workflows/cycle_carbon.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/cycle_carbon.yml
+++ b/.github/workflows/cycle_carbon.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/cycle_nitrogen.yml
+++ b/.github/workflows/cycle_nitrogen.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/cycle_nitrogen.yml
+++ b/.github/workflows/cycle_nitrogen.yml
@@ -64,6 +64,9 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
+        path: ./*.log.TABLE_NAME }}-automation-logs
+        path: ./*.log.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/cycle_nitrogen.yml
+++ b/.github/workflows/cycle_nitrogen.yml
@@ -65,8 +65,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.TABLE_NAME }}-automation-logs
-        path: ./*.log.TABLE_NAME }}-automation-logs
-        path: ./*.log.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/cycle_water.yml
+++ b/.github/workflows/cycle_water.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/cycle_water.yml
+++ b/.github/workflows/cycle_water.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/earthquake.yml
+++ b/.github/workflows/earthquake.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/earthquake.yml
+++ b/.github/workflows/earthquake.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/icecube.yml
+++ b/.github/workflows/icecube.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/icecube.yml
+++ b/.github/workflows/icecube.yml
@@ -64,6 +64,8 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
+        path: ./*.log.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/icecube.yml
+++ b/.github/workflows/icecube.yml
@@ -65,7 +65,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.TABLE_NAME }}-automation-logs
-        path: ./*.log.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/journalism.yml
+++ b/.github/workflows/journalism.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/journalism.yml
+++ b/.github/workflows/journalism.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/jowilder.yml
+++ b/.github/workflows/jowilder.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/jowilder.yml
+++ b/.github/workflows/jowilder.yml
@@ -64,6 +64,8 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
+        path: ./*.log.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/jowilder.yml
+++ b/.github/workflows/jowilder.yml
@@ -65,7 +65,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.TABLE_NAME }}-automation-logs
-        path: ./*.log.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -42,6 +42,7 @@ jobs:
 
   # 4. Cleanup & complete
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -45,4 +45,5 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log

--- a/.github/workflows/lakeland.yml
+++ b/.github/workflows/lakeland.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/lakeland.yml
+++ b/.github/workflows/lakeland.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/magnet.yml
+++ b/.github/workflows/magnet.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/magnet.yml
+++ b/.github/workflows/magnet.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/mashopolis.yml
+++ b/.github/workflows/mashopolis.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/mashopolis.yml
+++ b/.github/workflows/mashopolis.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/match.yml
+++ b/.github/workflows/match.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/match.yml
+++ b/.github/workflows/match.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/penguins.yml
+++ b/.github/workflows/penguins.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/penguins.yml
+++ b/.github/workflows/penguins.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/shadowspect.yml
+++ b/.github/workflows/shadowspect.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/shadowspect.yml
+++ b/.github/workflows/shadowspect.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/shipwrecks.yml
+++ b/.github/workflows/shipwrecks.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/shipwrecks.yml
+++ b/.github/workflows/shipwrecks.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/slide.yml
+++ b/.github/workflows/slide.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/slide.yml
+++ b/.github/workflows/slide.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/thermolab.yml
+++ b/.github/workflows/thermolab.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/thermolab.yml
+++ b/.github/workflows/thermolab.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/transformation_quest.yml
+++ b/.github/workflows/transformation_quest.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/transformation_quest.yml
+++ b/.github/workflows/transformation_quest.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/waves.yml
+++ b/.github/workflows/waves.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/waves.yml
+++ b/.github/workflows/waves.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/weather_station.yml
+++ b/.github/workflows/weather_station.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/weather_station.yml
+++ b/.github/workflows/weather_station.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:

--- a/.github/workflows/wind.yml
+++ b/.github/workflows/wind.yml
@@ -61,6 +61,7 @@ jobs:
     - name: Execute sync
       run: python3.8 main.py ${{ env.TABLE_NAME }} --max_days=${{ github.event.inputs.max_days || 7 }}
     - name: Upload logs as artifacts
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         path: ./*.log

--- a/.github/workflows/wind.yml
+++ b/.github/workflows/wind.yml
@@ -64,6 +64,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
+        name: ${{ env.TABLE_NAME }}-automation-logs
         path: ./*.log
 
   Cleanup_Synced_Rows:


### PR DESCRIPTION
Instead of wasting space on log files nobody will ever read (from successful runs), which are typically redundant with the output in the workflow summary on GH anyway, we'll only upload on failures (when someone might, maybe need them).

Also, needed to give a meaningful name to the uploaded files, so that anyone who wants to download them gets a name that isn't just the default `artifact.zip`, which isn't really a useful label.

Resolves #4 
Resolves #5 